### PR TITLE
Sudachi wrapper Gem for JRuby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+bin/sudachi

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec
+
+group :test do
+  gem 'minitest', '~> 5.12'
+end

--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
 # rudachi
-Sudachi wrapper for JRuby
+[Sudachi](https://github.com/WorksApplications/Sudachi) wrapper for JRuby.
+
+- Text base
+```rb
+Rudachi::TextParser.parse('東京都へ行く')
+=> "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都\nへ\t助詞,格助詞,*,*,*,*\tへ\n行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く\nEOS\n"
+```
+
+- File base
+```rb
+File.open('sample.txt', 'w') { |f| f << '東京都へ行く' }
+Rudachi::FileParser.parse('sample.txt')
+=> "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都\nへ\t助詞,格助詞,*,*,*,*\tへ\n行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く\nEOS\n"
+```
+
+- With some options
+```rb
+Rudachi::TextParser.new(o: 'result.txt', m: 'A').parse('東京都へ行く')
+File.read('result.txt')
+=> "東京\t名詞,固有名詞,地名,一般,*,*\t東京\n都\t名詞,普通名詞,一般,*,*,*\t都\nへ\t助詞,格助詞,*,*,*,*\tへ\n行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く\nEOS\n"
+```
+
+## Requirements
+
+- [JRuby](https://github.com/jruby/jruby) 9.1.3.0 or later
+- [Sudachi](https://github.com/WorksApplications/Sudachi)
+
+## Installation
+
+1. Install JAR and dictionary of Sudachi ([details](https://github.com/WorksApplications/Sudachi/blob/develop/docs/tutorial.md#linux-%E3%81%AE%E5%A0%B4%E5%90%88))
+
+- Install the Sudachi JAR file
+```sh
+$ wget https://github.com/WorksApplications/Sudachi/releases/download/v0.5.3/sudachi-0.5.3-executable.zip
+$ unzip sudachi-0.5.3-executable.zip
+$ ls sudachi-0.5.3
+LICENSE-2.0.txt  README.md  javax.json-1.1.jar	jdartsclone-1.2.0.jar  licenses  sudachi-0.5.3.jar  sudachi.json  sudachi_fulldict.json
+```
+
+- Install the Sudachi dictionary
+```sh
+$ wget http://sudachi.s3-website-ap-northeast-1.amazonaws.com/sudachidict/sudachi-dictionary-latest-full.zip
+$ unzip -j -d sudachi-dictionary-latest-full sudachi-dictionary-latest-full.zip
+$ mv sudachi-dictionary-latest-full/system_full.dic sudachi-dictionary-latest-full/system_core.dic
+$ ls sudachi-dictionary-latest-full
+LEGAL  LICENSE-2.0.txt	system_core.dic
+```
+
+2. Install Rudachi
+
+```rb
+# Gemfile
+gem 'rudachi', git: 'https://github.com/SongCastle/rudachi.git', tag: 'v1.0.0'
+```
+
+Then run `bundle install` .
+
+3. Initialize Rudachi
+
+```rb
+Rudachi.configure do |config|
+  config.jar_path = 'sudachi-0.5.3/sudachi-0.5.3.jar'
+end
+
+Rudachi::Option.configure do |config|
+  config.p = 'sudachi-dictionary-latest-full'
+end
+```
+
+4. Dit it !!
+
+```rb
+require 'rudachi'
+
+Rudachi::TextParser.parse('こんにちは世界')
+=> "こんにちは\t感動詞,一般,*,*,*,*\t今日は\n世界\t名詞,普通名詞,一般,*,*,*\t世界\nEOS\n"
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rudachi
-[Sudachi](https://github.com/WorksApplications/Sudachi) wrapper for JRuby.
+[Sudachi](https://github.com/WorksApplications/Sudachi) wrapper Gem for JRuby.
 
 - Text base
 ```rb

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+setup_sudachi () {
+    if [ -e sudachi ]; then
+    rm -rf sudachi
+    fi
+    mkdir -p sudachi/tmp
+    cd sudachi
+    wget -q -O tmp/sudachi-executable.zip https://github.com/WorksApplications/Sudachi/releases/download/v0.5.3/sudachi-0.5.3-executable.zip
+    wget -q -O tmp/sudachi-dictionary.zip http://sudachi.s3-website-ap-northeast-1.amazonaws.com/sudachidict/sudachi-dictionary-latest-full.zip
+    unzip -jqq -d tmp tmp/sudachi-executable.zip *.jar
+    unzip -jqq -d tmp tmp/sudachi-dictionary.zip *.dic
+    mv tmp/*.jar tmp/*.dic ./
+    mv system_full.dic system_core.dic
+    rm -rf tmp
+    touch pids
+}
+
+echo -n "\rInstalling Sudachi"
+setup_sudachi &
+
+until [ -e sudachi/pids ]
+do
+    echo -n "."
+    sleep 1
+done
+rm -f sudachi/pids
+
+echo "\nFinish setting up Sudachi !!"

--- a/lib/rudachi.rb
+++ b/lib/rudachi.rb
@@ -1,0 +1,3 @@
+require 'rudachi/config'
+require 'rudachi/file_parser'
+require 'rudachi/text_parser'

--- a/lib/rudachi/config.rb
+++ b/lib/rudachi/config.rb
@@ -1,0 +1,32 @@
+require 'rudachi/configurable'
+
+module Rudachi
+  extend Configurable
+
+  config_accessor :jar_path,  default: '/usr/java/lib/sudachi.jar'
+
+  module Option
+    extend Configurable
+
+    # @see https://github.com/WorksApplications/Sudachi#options
+    config_accessor :r,  default: nil
+    config_accessor :s,  default: nil
+    config_accessor :p,  default: '/usr/java/lib'
+    config_accessor :m,  default: 'C'
+    config_accessor :o,  default: nil
+    config_accessor :t,  default: nil
+    config_accessor :ts, default: nil
+    config_accessor :a,  default: nil
+    config_accessor :f,  default: nil
+    config_accessor :d,  default: nil
+    config_accessor :h,  default: nil
+
+    def self.cmds(opts)
+      class_variables.each_with_object([]) do |name, flags|
+        key = name.to_s.delete('@@')
+        val = opts[key] || opts[key.to_sym] || class_variable_get(name) or next
+        flags << "-#{key}" << val.to_s
+      end
+    end
+  end
+end

--- a/lib/rudachi/configurable.rb
+++ b/lib/rudachi/configurable.rb
@@ -1,0 +1,18 @@
+module Rudachi
+  module Configurable
+    def configure
+      yield self
+    end
+
+    private
+
+    def config_accessor(name, default: nil)
+      attr_def = <<~EOS
+        def self.#{name}; @@#{name}; end
+        def self.#{name}=(val); @@#{name} = val; end
+      EOS
+      module_eval(attr_def)
+      class_variable_set("@@#{name}", default)
+    end
+  end
+end

--- a/lib/rudachi/dependencies.rb
+++ b/lib/rudachi/dependencies.rb
@@ -1,0 +1,19 @@
+require 'java'
+java_import 'java.lang.System'
+java_import 'java.io.PrintStream'
+java_import 'java.io.ByteArrayInputStream'
+java_import 'java.io.ByteArrayOutputStream'
+java_import 'java.nio.charset.StandardCharsets'
+
+require Rudachi.jar_path
+java_import 'com.worksap.nlp.sudachi.SudachiCommandLine'
+
+module Java
+  String                = JavaLang::String
+  System                = JavaLang::System
+  ByteArrayInputStream  = JavaIo::ByteArrayInputStream
+  ByteArrayOutputStream = JavaIo::ByteArrayOutputStream
+  PrintStream           = JavaIo::PrintStream
+  UTF_8                 = JavaNioCharset::StandardCharsets::UTF_8
+  SudachiCommandLine    = ComWorksapNlpSudachi::SudachiCommandLine
+end

--- a/lib/rudachi/file_parser.rb
+++ b/lib/rudachi/file_parser.rb
@@ -1,0 +1,38 @@
+require 'rudachi/config'
+require 'rudachi/loader'
+
+module Rudachi
+  class FileParser
+    def self.parse(path)
+      new.parse(path)
+    end
+
+    def initialize(**opts)
+      Rudachi.load!
+
+      @output = Java::ByteArrayOutputStream.new
+      @opts   = opts
+    end
+
+    def parse(path)
+      take_stdout do
+        Java::SudachiCommandLine.main(
+          Option.cmds(@opts).push(Java::String.new(path))
+        )
+      end
+      @output.toString
+    end
+
+    private
+
+    def take_stdout
+      stdout = Java::System.out
+      stream = Java::PrintStream.new(@output)
+      Java::System.setOut(stream)
+
+      yield
+
+      Java::System.setOut(stdout)
+    end
+  end
+end

--- a/lib/rudachi/loader.rb
+++ b/lib/rudachi/loader.rb
@@ -1,0 +1,5 @@
+module Rudachi
+  def self.load!
+    require 'rudachi/dependencies'
+  end
+end

--- a/lib/rudachi/text_parser.rb
+++ b/lib/rudachi/text_parser.rb
@@ -1,0 +1,27 @@
+require 'rudachi/file_parser'
+
+module Rudachi
+  class TextParser < FileParser
+    def parse(text)
+      @input = Java::String.new(text)
+      take_stdin do
+        take_stdout do
+          Java::SudachiCommandLine.main(Option.cmds(@opts))
+        end
+      end
+      @output.toString
+    end
+
+    private
+
+    def take_stdin
+      stdin = Java::System.in
+      stream = Java::ByteArrayInputStream.new(@input.getBytes(Java::UTF_8))
+      Java::System.setIn(stream)
+
+      yield
+
+      Java::System.setIn(stdin)
+    end
+  end
+end

--- a/lib/rudachi/version.rb
+++ b/lib/rudachi/version.rb
@@ -1,0 +1,3 @@
+module Rudachi
+  VERSION = '1.0.0'
+end

--- a/rudachi.gemspec
+++ b/rudachi.gemspec
@@ -1,0 +1,20 @@
+lib = File.expand_path('../lib', __FILE__)
+$:.unshift(lib) unless $:.include?(lib)
+
+require 'rudachi/version'
+
+Gem::Specification.new do |s|
+  s.name        = 'rudachi'
+  s.version     = Rudachi::VERSION
+  s.platform    = Gem::Platform::RUBY
+  s.licenses    = 'MIT'
+  s.summary     = 'Sudachi wrapper for JRuby'
+  s.email       = '-'
+  s.homepage    = 'https://github.com/SongCastle/rudachi'
+  s.description = 'Sudachi wrapper for JRuby.'
+  s.author      = 'SongCastle'
+
+  s.files                 = Dir['lib/**/*', 'README.md']
+  s.require_paths         = ['lib']
+  s.required_ruby_version = Gem::Requirement.new('>= 2.3')
+end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,0 +1,25 @@
+require_relative 'test_helper'
+
+describe Rudachi do
+  describe '.configure' do
+    it 'set a JAR path as default' do
+      Rudachi.configure do |config|
+        config.jar_path = 'path/to/your_sudachi.jar'
+      end
+
+      expect(Rudachi.jar_path).must_equal('path/to/your_sudachi.jar')
+    end
+  end
+end
+
+describe Rudachi::Option do
+  describe '.configure' do
+    it 'set "p" option as default' do
+      Rudachi::Option.configure do |config|
+        config.p = 'path/to/your_root_sudachi'
+      end
+
+      expect(Rudachi::Option.p).must_equal('path/to/your_root_sudachi')
+    end
+  end
+end

--- a/test/test_file_parser.rb
+++ b/test/test_file_parser.rb
@@ -1,0 +1,130 @@
+require_relative 'test_helper'
+
+describe Rudachi::FileParser do
+  before do
+    File.open('./target.txt', 'w') do |f|
+      f << '東京都へ行く'
+    end
+  end
+
+  after do
+    File.delete('./target.txt')
+  end
+
+  describe '.parse' do
+    it 'returns analyzed words' do
+      ret = Rudachi::FileParser.parse('./target.txt')
+
+      expect(ret).must_be_kind_of(String)
+      expect(ret.split(?\n)).must_equal([
+        "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",
+        "へ\t助詞,格助詞,*,*,*,*\tへ",
+        "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+        "EOS"
+      ])
+    end
+
+    describe 'when with "o" option' do
+      before do
+        Rudachi::Option.configure do |config|
+          config.o = './result.txt'
+        end
+      end
+
+      after do
+        File.delete('./result.txt')
+        Rudachi::Option.configure do |config|
+          config.o = nil
+        end
+      end
+
+      it 'writes analyzed words to a output file' do
+        ret = Rudachi::FileParser.parse('./target.txt')
+
+        expect(ret).must_equal("")
+        expect(File.exist?('./result.txt')).must_equal(true)
+        output = File.read('./result.txt')
+        expect(output.split(?\n)).must_equal([
+          "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",
+          "へ\t助詞,格助詞,*,*,*,*\tへ",
+          "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+          "EOS"
+        ])
+      end
+    end
+
+    describe 'when with "m" option' do
+      before do
+        Rudachi::Option.configure do |config|
+          config.m = 'A'
+        end
+      end
+
+      after do
+        Rudachi::Option.configure do |config|
+          config.m = 'C'
+        end
+      end
+
+      it 'returns analyzed words by mode "A"' do
+        ret = Rudachi::FileParser.parse('./target.txt')
+
+        expect(ret).must_be_kind_of(String)
+        expect(ret.split(?\n)).must_equal([
+          "東京\t名詞,固有名詞,地名,一般,*,*\t東京",
+          "都\t名詞,普通名詞,一般,*,*,*\t都",
+          "へ\t助詞,格助詞,*,*,*,*\tへ",
+          "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+          "EOS"
+        ])
+      end
+    end
+  end
+
+  describe '#parse' do
+    it 'returns analyzed words' do
+      ret = Rudachi::FileParser.new.parse('./target.txt')
+
+      expect(ret).must_be_kind_of(String)
+      expect(ret.split(?\n)).must_equal([
+        "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",
+        "へ\t助詞,格助詞,*,*,*,*\tへ",
+        "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+        "EOS"
+      ])
+    end
+
+    describe 'when with "o" option' do
+      after { File.delete('./result.txt') }
+
+      it 'writes analyzed words to a output file' do
+        ret = Rudachi::FileParser.new(o: './result.txt').parse('./target.txt')
+
+        expect(ret).must_equal("")
+        expect(File.exist?('./result.txt')).must_equal(true)
+        output = File.read('./result.txt')
+        expect(output.split(?\n)).must_equal([
+          "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",
+          "へ\t助詞,格助詞,*,*,*,*\tへ",
+          "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+          "EOS"
+        ])
+      end
+    end
+
+    describe 'when with "m" option' do
+      it 'returns analyzed words by mode "A"' do
+        ret = Rudachi::FileParser.new(m: 'A').parse('./target.txt')
+
+        expect(ret).must_be_kind_of(String)
+        expect(ret.split(?\n)).must_equal([
+          "東京\t名詞,固有名詞,地名,一般,*,*\t東京",
+          "都\t名詞,普通名詞,一般,*,*,*\t都",
+          "へ\t助詞,格助詞,*,*,*,*\tへ",
+          "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+          "EOS"
+        ])
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,16 @@
+lib = File.expand_path('../../lib', __FILE__)
+$:.unshift(lib) unless $:.include?(lib)
+
+require 'minitest/autorun'
+require 'rudachi'
+require 'rudachi/version'
+
+MiniTest::Spec.before do
+  Rudachi.configure do |config|
+    config.jar_path = File.expand_path('bin/sudachi/sudachi-0.5.3.jar', Dir.pwd)
+  end
+
+  Rudachi::Option.configure do |config|
+    config.p = File.expand_path('bin/sudachi', Dir.pwd)
+  end
+end

--- a/test/test_text_parser.rb
+++ b/test/test_text_parser.rb
@@ -1,0 +1,120 @@
+require_relative 'test_helper'
+
+describe Rudachi::TextParser do
+  describe '.parse' do
+    it 'returns analyzed words' do
+      ret = Rudachi::TextParser.parse('東京都へ行く')
+
+      expect(ret).must_be_kind_of(String)
+      expect(ret.split(?\n)).must_equal([
+        "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",
+        "へ\t助詞,格助詞,*,*,*,*\tへ",
+        "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+        "EOS"
+      ])
+    end
+
+    describe 'when with "o" option' do
+      before do
+        Rudachi::Option.configure do |config|
+          config.o = './result.txt'
+        end
+      end
+
+      after do
+        File.delete('./result.txt')
+        Rudachi::Option.configure do |config|
+          config.o = nil
+        end
+      end
+
+      it 'writes analyzed words to a output file' do
+        ret = Rudachi::TextParser.parse('東京都へ行く')
+
+        expect(ret).must_equal("")
+        expect(File.exist?('./result.txt')).must_equal(true)
+        output = File.read('./result.txt')
+        expect(output.split(?\n)).must_equal([
+          "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",
+          "へ\t助詞,格助詞,*,*,*,*\tへ",
+          "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+          "EOS"
+        ])
+      end
+    end
+
+    describe 'when with "m" option' do
+      before do
+        Rudachi::Option.configure do |config|
+          config.m = 'A'
+        end
+      end
+
+      after do
+        Rudachi::Option.configure do |config|
+          config.m = 'C'
+        end
+      end
+
+      it 'returns analyzed words by mode "A"' do
+        ret = Rudachi::TextParser.parse('東京都へ行く')
+
+        expect(ret).must_be_kind_of(String)
+        expect(ret.split(?\n)).must_equal([
+          "東京\t名詞,固有名詞,地名,一般,*,*\t東京",
+          "都\t名詞,普通名詞,一般,*,*,*\t都",
+          "へ\t助詞,格助詞,*,*,*,*\tへ",
+          "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+          "EOS"
+        ])
+      end
+    end
+  end
+
+  describe '#parse' do
+    it 'returns analyzed words' do
+      ret = Rudachi::TextParser.new.parse('東京都へ行く')
+
+      expect(ret).must_be_kind_of(String)
+      expect(ret.split(?\n)).must_equal([
+        "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",
+        "へ\t助詞,格助詞,*,*,*,*\tへ",
+        "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+        "EOS"
+      ])
+    end
+
+    describe 'when with "o" option' do
+      after { File.delete('./result.txt') }
+
+      it 'writes analyzed words to a output file' do
+        ret = Rudachi::TextParser.new(o: './result.txt').parse('東京都へ行く')
+
+        expect(ret).must_equal("")
+        expect(File.exist?('./result.txt')).must_equal(true)
+        output = File.read('./result.txt')
+        expect(output.split(?\n)).must_equal([
+          "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",
+          "へ\t助詞,格助詞,*,*,*,*\tへ",
+          "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+          "EOS"
+        ])
+      end
+    end
+
+    describe 'when with "m" option' do
+      it 'returns analyzed words by mode "A"' do
+        ret = Rudachi::TextParser.new(m: 'A').parse('東京都へ行く')
+
+        expect(ret).must_be_kind_of(String)
+        expect(ret.split(?\n)).must_equal([
+          "東京\t名詞,固有名詞,地名,一般,*,*\t東京",
+          "都\t名詞,普通名詞,一般,*,*,*\t都",
+          "へ\t助詞,格助詞,*,*,*,*\tへ",
+          "行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く",
+          "EOS"
+        ])
+      end
+    end
+  end
+end

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -1,0 +1,7 @@
+require_relative 'test_helper'
+
+describe Rudachi::VERSION do
+  it 'current Rudachi version' do
+    expect(Rudachi::VERSION).must_equal('1.0.0')
+  end
+end


### PR DESCRIPTION
## Summary
Create Sudachi wrapper Gem for JRuby.

- Text base
```rb
Rudachi::TextParser.parse('東京都へ行く')
=> "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都\nへ\t助詞,格助詞,*,*,*,*\tへ\n行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く\nEOS\n"
```

- File base
```rb
File.open('sample.txt', 'w') { |f| f << '東京都へ行く' }
Rudachi::FileParser.parse('sample.txt')
=> "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都\nへ\t助詞,格助詞,*,*,*,*\tへ\n行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く\nEOS\n"
```

- With some options
```rb
Rudachi::TextParser.new(o: 'result.txt', m: 'A').parse('東京都へ行く')
File.read('result.txt')
=> "東京\t名詞,固有名詞,地名,一般,*,*\t東京\n都\t名詞,普通名詞,一般,*,*,*\t都\nへ\t助詞,格助詞,*,*,*,*\tへ\n行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く\nEOS\n"
```