### PR TITLE
Bump option handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Rudachi
 [Sudachi](https://github.com/WorksApplications/Sudachi) wrapper Gem for JRuby.
 
-#### Text base
+#### Text
 ```rb
 Rudachi::TextParser.parse('東京都へ行く')
 => "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都\nへ\t助詞,格助詞,*,*,*,*\tへ\n行く\t動詞,非自立可能,*,*,五段-カ行,終止形-一般\t行く\nEOS\n"
 ```
 
-#### File base
+#### File
 ```rb
 File.open('sample.txt', 'w') { |f| f << '東京都へ行く' }
 Rudachi::FileParser.parse('sample.txt')

--- a/lib/rudachi.rb
+++ b/lib/rudachi.rb
@@ -1,3 +1,4 @@
 require 'rudachi/config'
+require 'rudachi/option/config'
 require 'rudachi/file_parser'
 require 'rudachi/text_parser'

--- a/lib/rudachi/config.rb
+++ b/lib/rudachi/config.rb
@@ -1,32 +1,8 @@
 require 'rudachi/configurable'
+require 'rudachi/option/string_option'
 
 module Rudachi
   extend Configurable
 
-  config_accessor :jar_path,  default: '/usr/java/lib/sudachi.jar'
-
-  module Option
-    extend Configurable
-
-    # @see https://github.com/WorksApplications/Sudachi#options
-    config_accessor :r,  default: nil
-    config_accessor :s,  default: nil
-    config_accessor :p,  default: '/usr/java/lib'
-    config_accessor :m,  default: 'C'
-    config_accessor :o,  default: nil
-    config_accessor :t,  default: nil
-    config_accessor :ts, default: nil
-    config_accessor :a,  default: nil
-    config_accessor :f,  default: nil
-    config_accessor :d,  default: nil
-    config_accessor :h,  default: nil
-
-    def self.cmds(opts)
-      class_variables.each_with_object([]) do |name, flags|
-        key = name.to_s.delete('@@')
-        val = opts[key] || opts[key.to_sym] || class_variable_get(name) or next
-        flags << "-#{key}" << val.to_s
-      end
-    end
-  end
+  config_accessor :jar_path, klass: Option::StringOption, default: '/usr/java/lib/sudachi.jar'
 end

--- a/lib/rudachi/configurable.rb
+++ b/lib/rudachi/configurable.rb
@@ -6,13 +6,13 @@ module Rudachi
 
     private
 
-    def config_accessor(name, default: nil)
+    def config_accessor(name, klass:, default:)
       attr_def = <<~EOS
         def self.#{name}; @@#{name}; end
-        def self.#{name}=(val); @@#{name} = val; end
+        def self.#{name}=(val); @@#{name} = #{klass}.new(val); end
       EOS
       module_eval(attr_def)
-      class_variable_set("@@#{name}", default)
+      public_send("#{name}=", default)
     end
   end
 end

--- a/lib/rudachi/file_parser.rb
+++ b/lib/rudachi/file_parser.rb
@@ -1,4 +1,4 @@
-require 'rudachi/config'
+require 'rudachi/option/config'
 require 'rudachi/loader'
 
 module Rudachi
@@ -11,7 +11,7 @@ module Rudachi
       Rudachi.load!
 
       @output = Java::ByteArrayOutputStream.new
-      @opts   = opts
+      @opts   = Option.new(opts)
     end
 
     def parse(path)

--- a/lib/rudachi/option/boolean_option.rb
+++ b/lib/rudachi/option/boolean_option.rb
@@ -1,0 +1,14 @@
+module Rudachi
+  class Option
+    class BooleanOption < Delegator
+      def initialize(bool)
+        raise ArgumentError, 'must be `false` or `true`' unless bool.is_a?(FalseClass) || bool.is_a?(TrueClass)
+        @value = bool
+      end
+
+      def __getobj__; @value; end
+      def enable?; @value; end
+      def with_arg?; false; end
+    end
+  end
+end

--- a/lib/rudachi/option/config.rb
+++ b/lib/rudachi/option/config.rb
@@ -1,0 +1,47 @@
+require 'rudachi/configurable'
+require 'rudachi/option/boolean_option'
+require 'rudachi/option/string_option'
+
+module Rudachi
+  class Option
+    extend Configurable
+
+    # @see https://github.com/WorksApplications/Sudachi#options
+    config_accessor :r,  klass: StringOption,  default: nil
+    config_accessor :s,  klass: StringOption,  default: nil
+    config_accessor :p,  klass: StringOption,  default: nil
+    config_accessor :m,  klass: StringOption,  default: nil
+    config_accessor :o,  klass: StringOption,  default: nil
+    config_accessor :a,  klass: BooleanOption, default: false
+    config_accessor :d,  klass: BooleanOption, default: false
+    config_accessor :t,  klass: BooleanOption, default: false
+    config_accessor :ts, klass: BooleanOption, default: false
+    config_accessor :f,  klass: BooleanOption, default: false
+    config_accessor :h,  klass: BooleanOption, default: false
+
+    def self.cmds(opts=Option.new)
+      class_variables.each_with_object([]) do |name, flags|
+        key = name[2..-1].to_sym
+        opt = opts.get(key) { class_variable_get(name) }
+        next unless opt&.enable?
+        flags << "-#{key}"
+        flags << opt.to_s if opt.with_arg?
+      end
+    end
+
+    def initialize(**hash)
+      @opts = hash.each_with_object({}) do |(key, val), _hash|
+        raise ArgumentError, %{unknown option "#{key}"} unless self.class.class_variable_defined?("@@#{key}")
+        begin
+          _hash[key.to_sym] = self.class.class_variable_get("@@#{key}").class.new(val)
+        rescue ArgumentError => e
+          raise ArgumentError, %{"#{key}" #{e.message}}
+        end
+      end
+    end
+
+    def get(key, &block)
+      @opts.key?(key) ? @opts[key] : block&.call
+    end
+  end
+end

--- a/lib/rudachi/option/string_option.rb
+++ b/lib/rudachi/option/string_option.rb
@@ -1,0 +1,14 @@
+module Rudachi
+  class Option
+    class StringOption < Delegator
+      def initialize(str)
+        raise ArgumentError, 'must be `nil` or `String`' unless str.nil? || str.is_a?(String)
+        @value = str
+      end
+
+      def __getobj__; @value; end
+      def enable?; !!@value; end
+      def with_arg?; true; end
+    end
+  end
+end

--- a/test/option/test_boolean_option.rb
+++ b/test/option/test_boolean_option.rb
@@ -1,0 +1,44 @@
+require_relative '../test_helper'
+
+describe Rudachi::Option::BooleanOption do
+  describe '#initialize' do
+    it 'returns an instance' do
+      expect { Rudachi::Option::BooleanOption.new(false) }.wont_raise
+    end
+
+    describe 'when with an invalid arg' do
+      it 'raises `ArgumentError`' do
+        err = expect { Rudachi::Option::BooleanOption.new(-1) }.must_raise
+        expect(err.message).must_equal('must be `false` or `true`')
+      end
+    end
+  end
+
+  describe '#enable?' do
+    it 'returns `false`' do
+      opt = Rudachi::Option::BooleanOption.new(false)
+      expect(opt.enable?).must_equal(false)
+    end
+
+    describe 'when with `true`' do
+      it 'returns `true`' do
+        opt = Rudachi::Option::BooleanOption.new(true)
+        expect(opt.enable?).must_equal(true)
+      end
+    end
+  end
+
+  describe '#with_arg?' do
+    it 'always returns `false`' do
+      opt = Rudachi::Option::BooleanOption.new(false)
+      expect(opt.with_arg?).must_equal(false)
+    end
+
+    describe 'when with `true`' do
+      it 'always returns `false`' do
+        opt = Rudachi::Option::BooleanOption.new(true)
+        expect(opt.with_arg?).must_equal(false)
+      end
+    end
+  end
+end

--- a/test/option/test_config.rb
+++ b/test/option/test_config.rb
@@ -1,0 +1,128 @@
+require_relative '../test_helper'
+
+describe Rudachi::Option do
+  describe '.configure' do
+    it 'set "p" option as default' do
+      Rudachi::Option.configure do |config|
+        config.p = 'path/to/your_root_sudachi'
+      end
+
+      expect(Rudachi::Option.p).must_be(:==, 'path/to/your_root_sudachi')
+    end
+
+    describe 'when an invaid configuration' do
+      describe 'when `StringOption`' do
+        it 'raises `ArgumentError`' do
+          Rudachi::Option.configure do |config|
+            err = expect {
+              config.p = false
+            }.must_raise(ArgumentError)
+            expect(err.message).must_equal('must be `nil` or `String`')
+          end
+        end
+      end
+
+      describe 'when `BooleanOption`' do
+        it 'raises `ArgumentError`' do
+          Rudachi::Option.configure do |config|
+            err = expect {
+              config.a = 'a'
+            }.must_raise(ArgumentError)
+            expect(err.message).must_equal('must be `false` or `true`')
+          end
+        end
+      end
+    end
+  end
+
+  describe '.cmds' do
+    before do
+      Rudachi::Option.configure do |config|
+        config.p = 'path/to/your_root_sudachi'
+      end
+    end
+
+    it 'returns an array for command line' do
+      expect(Rudachi::Option.cmds).must_equal(['-p', 'path/to/your_root_sudachi'])
+    end
+
+    describe 'when with args' do
+      it 'returns an array for command line' do
+        expect(Rudachi::Option.cmds(
+          Rudachi::Option.new(a: false, d: true, m: 'A', r: nil)
+        ).sort).must_equal(['-p', 'path/to/your_root_sudachi', '-m', 'A', '-d'].sort)
+      end
+
+      describe 'when overwrite the default args' do
+        it 'returns an array for command line' do
+          p_opt = 'path/to/your_root_sudachi'.reverse
+          expect(
+            Rudachi::Option.cmds(Rudachi::Option.new(p: p_opt))
+          ).must_equal(['-p', p_opt])
+        end
+      end
+    end
+  end
+
+  describe '#initialize' do
+    it 'returns an instance' do
+      expect { Rudachi::Option.new }.wont_raise
+    end
+
+    describe 'when with some valid args' do
+      it 'returns an instance' do
+        opts = expect { Rudachi::Option.new(m: 'A', a: false) }.wont_raise
+        expect(opts.get(:m)).must_be(:==, 'A')
+        expect(opts.get(:a)).must_be(:==, false)
+      end
+    end
+
+    describe 'when with an invalid arg' do
+      it 'raises `ArgumentError`' do
+        err = expect { Rudachi::Option.new(m: 'A', a: -1) }.must_raise(ArgumentError)
+        expect(err.message).must_equal('"a" must be `false` or `true`')
+      end
+    end
+
+    describe 'when with an unknown option' do
+      it 'raises `ArgumentError`' do
+        err = expect { Rudachi::Option.new(x: -1) }.must_raise(ArgumentError)
+        expect(err.message).must_equal('unknown option "x"')
+      end
+    end
+  end
+
+  describe '#get' do
+    it 'returns a target option' do
+      opts = Rudachi::Option.new(m: 'A')
+      expect(opts.get(:m)).must_be(:==, 'A')
+    end
+
+    describe 'when with a block' do
+      it 'returns a target option' do
+        opts = Rudachi::Option.new(m: 'A')
+
+        expect(
+          opts.get(:m) { Rudachi::Option::StringOption.new('B') }
+        ).must_be(:==, 'A')
+      end
+
+      describe 'when the target option doesn\'t exist' do
+        it 'returns a option that given the block' do
+          opts = Rudachi::Option.new
+
+          expect(
+            opts.get(:m) { Rudachi::Option::StringOption.new('B') }
+          ).must_be(:==, 'B')
+        end
+      end
+    end
+
+    describe 'when the target option doesn\'t exist' do
+      it 'returns `nil`' do
+        opts = Rudachi::Option.new
+        expect(opts.get(:m)).must_be_nil
+      end
+    end
+  end
+end

--- a/test/option/test_string_option.rb
+++ b/test/option/test_string_option.rb
@@ -1,0 +1,50 @@
+require_relative '../test_helper'
+
+describe Rudachi::Option::StringOption do
+  describe '#initialize' do
+    it 'returns an instance' do
+      expect { Rudachi::Option::StringOption.new('A') }.wont_raise
+    end
+
+    describe 'when with `nil`' do
+      it 'returns an instance' do
+        expect { Rudachi::Option::StringOption.new(nil) }.wont_raise
+      end
+    end
+
+    describe 'when with an invalid arg' do
+      it 'raises `ArgumentError`' do
+        err = expect { Rudachi::Option::StringOption.new(-1) }.must_raise
+        expect(err.message).must_equal('must be `nil` or `String`')
+      end
+    end
+  end
+
+  describe '#enable?' do
+    it 'returns `true`' do
+      opt = Rudachi::Option::StringOption.new('A')
+      expect(opt.enable?).must_equal(true)
+    end
+
+    describe 'when with `nil`' do
+      it 'returns `false`' do
+        opt = Rudachi::Option::StringOption.new(nil)
+        expect(opt.enable?).must_equal(false)
+      end
+    end
+  end
+
+  describe '#with_arg?' do
+    it 'always returns `true`' do
+      opt = Rudachi::Option::StringOption.new('A')
+      expect(opt.with_arg?).must_equal(true)
+    end
+
+    describe 'when with `nil`' do
+      it 'always returns `true`' do
+        opt = Rudachi::Option::StringOption.new(nil)
+        expect(opt.with_arg?).must_equal(true)
+      end
+    end
+  end
+end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -7,19 +7,18 @@ describe Rudachi do
         config.jar_path = 'path/to/your_sudachi.jar'
       end
 
-      expect(Rudachi.jar_path).must_equal('path/to/your_sudachi.jar')
+      expect(Rudachi.jar_path).must_be(:==, 'path/to/your_sudachi.jar')
     end
-  end
-end
 
-describe Rudachi::Option do
-  describe '.configure' do
-    it 'set "p" option as default' do
-      Rudachi::Option.configure do |config|
-        config.p = 'path/to/your_root_sudachi'
+    describe 'when an invaid configuration' do
+      it 'raises `ArgumentError`' do
+        Rudachi.configure do |config|
+          err = expect {
+            config.jar_path = false
+          }.must_raise(ArgumentError)
+          expect(err.message).must_equal('must be `nil` or `String`')
+        end
       end
-
-      expect(Rudachi::Option.p).must_equal('path/to/your_root_sudachi')
     end
   end
 end

--- a/test/test_file_parser.rb
+++ b/test/test_file_parser.rb
@@ -41,8 +41,8 @@ describe Rudachi::FileParser do
       it 'writes analyzed words to a output file' do
         ret = Rudachi::FileParser.parse('./target.txt')
 
-        expect(ret).must_equal("")
-        expect(File.exist?('./result.txt')).must_equal(true)
+        expect(ret).must_equal('')
+        expect('./result.txt').path_must_exist
         output = File.read('./result.txt')
         expect(output.split(?\n)).must_equal([
           "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",
@@ -100,8 +100,8 @@ describe Rudachi::FileParser do
       it 'writes analyzed words to a output file' do
         ret = Rudachi::FileParser.new(o: './result.txt').parse('./target.txt')
 
-        expect(ret).must_equal("")
-        expect(File.exist?('./result.txt')).must_equal(true)
+        expect(ret).must_equal('')
+        expect('./result.txt').path_must_exist
         output = File.read('./result.txt')
         expect(output.split(?\n)).must_equal([
           "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,38 @@ require 'minitest/autorun'
 require 'rudachi'
 require 'rudachi/version'
 
-MiniTest::Spec.before do
+module MiniTest
+  module Assertions
+    def refute_raises(msg = nil, &block)
+      flunk "assert_raises requires a block to capture errors." unless block
+
+      msg = message(msg) do
+        "Expected #{block} to not be raised any exception.\n"
+      end
+
+      ret =
+        begin
+          yield
+        rescue Minitest::Assertion, SignalException, SystemExit
+          raise
+        rescue Exception => e
+          flunk proc {
+            exception_details(e, "#{msg.call}#{mu_pp(block)} exception expected, not")
+          }
+          return e
+        end
+
+      pass
+      ret
+    end
+  end
+
+  module Expectations
+    infect_an_assertion :refute_raises, :wont_raise, :block
+  end
+end
+
+Minitest::Spec.before do
   Rudachi.configure do |config|
     config.jar_path = File.expand_path('bin/sudachi/sudachi-0.5.3.jar', Dir.pwd)
   end

--- a/test/test_text_parser.rb
+++ b/test/test_text_parser.rb
@@ -31,8 +31,8 @@ describe Rudachi::TextParser do
       it 'writes analyzed words to a output file' do
         ret = Rudachi::TextParser.parse('東京都へ行く')
 
-        expect(ret).must_equal("")
-        expect(File.exist?('./result.txt')).must_equal(true)
+        expect(ret).must_equal('')
+        expect('./result.txt').path_must_exist
         output = File.read('./result.txt')
         expect(output.split(?\n)).must_equal([
           "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",
@@ -90,8 +90,8 @@ describe Rudachi::TextParser do
       it 'writes analyzed words to a output file' do
         ret = Rudachi::TextParser.new(o: './result.txt').parse('東京都へ行く')
 
-        expect(ret).must_equal("")
-        expect(File.exist?('./result.txt')).must_equal(true)
+        expect(ret).must_equal('')
+        expect('./result.txt').path_must_exist
         output = File.read('./result.txt')
         expect(output.split(?\n)).must_equal([
           "東京都\t名詞,固有名詞,地名,一般,*,*\t東京都",


### PR DESCRIPTION
## Summary
Bump and fix below.

### Changes
- Handling invalid options

```rb
Rudachi::Option.configure do |config|
  config.p = false
end
> ArgumentError: 'must be `nil` or `String`'
```

- Fix a bool option bug (Some bool options may be unintentionally ignored.)

```rb
# Default options
Rudachi::Option.configure do |config|
  config.a = true
end
# Custom options
Rudachi::TextParser.new(a: false).text('東京都へ行く')
# > The "a" option is passed as `false` to Sudachi.
```